### PR TITLE
Update Celery command-line arguments for v5.2

### DIFF
--- a/rootfs/etc/services.d/jutut-celery-beat/run
+++ b/rootfs/etc/services.d/jutut-celery-beat/run
@@ -24,8 +24,9 @@ s6-env HOME=${home}
 cd ${home}
 
 # run daemon
-${python3} -m celery beat
+${python3} -m celery
+ --app jutut
+ beat
  --pidfile=${run}/celery-beat.pid
  --loglevel=info
  --schedule=/local/jutut/celery-beat-schedule
- --app jutut

--- a/rootfs/etc/services.d/jutut-celery-worker/run
+++ b/rootfs/etc/services.d/jutut-celery-worker/run
@@ -24,8 +24,9 @@ s6-env HOME=${home}
 cd ${home}
 
 # run daemon
-${python3} -m celery worker
+${python3} -m celery
+ --app jutut
+ worker
  --pidfile=${run}/celery-worker.pid
  --loglevel=info
  --autoscale=6,1
- --app jutut


### PR DESCRIPTION
# Description

**What?**

Update Celery command-line arguments to support Celery 5.

**Why?**

This is needed to upgrade MOOC-Jutut to Celery 5.2.


# Testing

Tested to work.