### PR TITLE
Add support for multiarch container images (amd64/arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apluslms/service-base:django-1.17
+FROM --platform=$TARGETPLATFORM apluslms/service-base:django-1.18
 
 # Set container related configuration via environment variables
 ENV CONTAINER_TYPE="jutut" \

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
+docker buildx build \
+--push \
+--tag "$DOCKER_REPO":"$DOCKER_TAG" \
+--platform linux/amd64,linux/arm64 .

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+# This hook is empty because the image was pushed to the registry in the build hook


### PR DESCRIPTION
# Description

**What?**

Add support for automatic building of multi-architecture container images (amd64/arm64).

This PR requires that service-base has multi-architecture support first.

**Why?**

Container images built with support for the ARM architecture perform much better on Apple Silicon laptops.

**How?**

A custom build hook is used to build the image for amd64 and arm64.
The image is pushed to Docker Hub in the build hook.

Links about the docker buildx plugin for future reference:
- https://github.com/docker/buildx
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
- https://hub.docker.com/r/tonistiigi/binfmt

# Testing

I tested that Docker Hub Automated Builds work as expected.